### PR TITLE
Display current minute instead of date for live matches

### DIFF
--- a/src/components/MatchNav/MatchNavItem/MatchNavItem.jsx
+++ b/src/components/MatchNav/MatchNavItem/MatchNavItem.jsx
@@ -14,7 +14,7 @@ const nonSelectedStyle = {
 const MatchNavItem = props => (
   <element left={props.left} top={0} height={2} width={props.width}>
     <box
-      content={getFormattedDatetime(props.match)}
+      content={getFormattedDatetime(props.match, true)}
       top={0}
       align="center"
       width="100%"

--- a/src/format.js
+++ b/src/format.js
@@ -75,7 +75,11 @@ function getFormattedMatch(match) {
   return getFormattedNonCompletedMatch(match);
 }
 
-function getFormattedDatetime(match) {
+function getFormattedDatetime(match, displayMinuteIfLive = false) {
+  if (displayMinuteIfLive && match.status === 'in progress') {
+    return `LIVE ${match.time}`;
+  }
+
   return moment(match.datetime)
     .local()
     .format('L LT');


### PR DESCRIPTION
<img width="589" alt="screen shot 2018-06-25 at 9 49 27 pm" src="https://user-images.githubusercontent.com/1479924/41884592-1acb487a-78c2-11e8-9639-aaf157684783.png">

Addresses #15 
