### PR TITLE
Remove match event emojis

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "chalk": "^2.4.1",
     "country-emoji": "^1.2.0",
     "moment": "^2.22.2",
-    "node-emoji": "^1.8.1",
     "prop-types": "^15.6.1",
     "react": "^16.4.1",
     "react-blessed": "^0.2.1"

--- a/src/format.js
+++ b/src/format.js
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import emoji from 'node-emoji';
 import moment from 'moment';
 import { flag } from 'country-emoji';
 

--- a/src/format.js
+++ b/src/format.js
@@ -106,37 +106,14 @@ function getEventTypeFriendlyName(eventType) {
   return eventFriendlyNames.get(eventType);
 }
 
-function getEventTypeEmoji(eventType) {
-  const eventEmojis = new Map([
-    ['yellow-card', emoji.get('warning')],
-    ['yellow-card-second', emoji.get('warning')],
-    ['red-card', emoji.get('red_circle')],
-    ['goal', emoji.get('soccer')],
-    ['substitution-in', emoji.get('arrow_forward')],
-    ['substitution-out', emoji.get('arrow_backward')],
-    ['penalty-kick', emoji.get('scream')],
-    ['goal-penalty', emoji.get('soccer')],
-    ['goal-own', emoji.get('soccer')],
-  ]);
-
-  if (!config.shouldIncludeEmojis) {
-    return getEventTypeFriendlyName(eventType);
-  }
-
-  if (!eventEmojis.has(eventType)) {
-    return eventType;
-  }
-  return eventEmojis.get(eventType);
-}
-
 function getFormattedMatchEventLeft(event) {
-  return `${getEventTypeEmoji(event.type_of_event)} ${event.time} ${
+  return `${getEventTypeFriendlyName(event.type_of_event)} ${event.time} ${
     event.player
   }`;
 }
 
 function getFormattedMatchEventRight(event) {
-  return `${event.player} ${event.time} ${getEventTypeEmoji(
+  return `${event.player} ${event.time} ${getEventTypeFriendlyName(
     event.type_of_event,
   )}`;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2105,10 +2105,6 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash.toarray@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.toarray/-/lodash.toarray-4.4.0.tgz#24c4bfcd6b2fba38bfd0594db1179d8e9b656561"
-
 lodash@^4.17.4, lodash@^4.3.0, lodash@^4.x.x:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
@@ -2258,12 +2254,6 @@ needle@^2.2.0:
     debug "^2.1.2"
     iconv-lite "^0.4.4"
     sax "^1.2.4"
-
-node-emoji@^1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.8.1.tgz#6eec6bfb07421e2148c75c6bba72421f8530a826"
-  dependencies:
-    lodash.toarray "^4.4.0"
 
 node-fetch@^1.0.1:
   version "1.7.3"


### PR DESCRIPTION
Match event emojis were causing a lot of rendering issues.

Plus, non-emojis match events are not that bad:
<img width="732" alt="screen shot 2018-06-28 at 10 04 10 pm" src="https://user-images.githubusercontent.com/1479924/42069555-6c73a40a-7b20-11e8-8383-00870c6d294e.png">
